### PR TITLE
fix broken theme spec site link

### DIFF
--- a/data/docs/tokens.mdx
+++ b/data/docs/tokens.mdx
@@ -45,7 +45,7 @@ export const { styled, css } = createStitches({
 });
 ```
 
-> This is based on the [System UI Theme Specification](https://system-ui.com/theme) by Brent Jackson.
+> This is based on the [System UI Theme Specification](https://theme-ui.com/theme-spec) by Brent Jackson.
 
 ### Using tokens
 


### PR DESCRIPTION
## Fix broken theme spec site link

Fix the broken reference link of "System UI Theme Specification" on "Theme Token"

